### PR TITLE
Django 1.9 でのテスト

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = {py27,py32,py33,py34,pypy,pypy3}-django{17,18}, coverage, docs, flake8
+envlist = {py27,py32,py33,py34,pypy,pypy3}-django{17,18}, {py27,py34,pypy}-django19, coverage, docs, flake8
 
 [testenv]
 deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9a1,<2.0
 commands =
     pip install -e .[test]
     ./runtests.py


### PR DESCRIPTION
Django 1.9 alpha 1 がリリースされたので, Django 1.9 でのテストを tox に追加する.