### PR TITLE
Python 3.5 でのテストを追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - 3.5
 install:
   - pip install 'tox>=2.1,<2.2'
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py32,py33,py34,pypy,pypy3}-django{17,18}, {py27,py34,pypy}-django19, coverage, docs, flake8
+envlist = {py27,py32,py33,py34,pypy,pypy3}-django{17,18}, {py27,py34,py35,pypy}-django19, coverage, docs, flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.5 でのテストを追加する.

Travis CI のビルドイメージの更新待ち.
travis-ci/travis-ci#4794