### PR TITLE
Yo のテキスト対応

### DIFF
--- a/channels/backends/yo.py
+++ b/channels/backends/yo.py
@@ -22,6 +22,10 @@ class YoChannel(BaseChannel):
         if self.username is not None:
             payload["username"] = self.username
 
+        if message is not None:
+            # 30 characters max
+            payload["text"] = message
+
         self._set_payload_from_options(payload, options, "yo", [
             "username", "link", "location"])
 

--- a/docs/source/backends/yo.rst
+++ b/docs/source/backends/yo.rst
@@ -24,6 +24,18 @@ You can obtain an API token from `Yo Dashboard`_.
        }
    }
 
+Text
+----
+You can send Yo with text (30 characters max) with Yo API v2.0.
+
+.. code-block:: python
+
+   import channels
+
+   # Yo with text
+   self.channel.send("text")
+
+
 Options
 -------
 You can send Yo Location or Yo Link by specifying options. For example:
@@ -32,13 +44,15 @@ You can send Yo Location or Yo Link by specifying options. For example:
 
    import channels
 
-   self.channel.send("Yo Link", options={
+   # Yo Link
+   self.channel.send(None, options={
        "yo": {
            "link": "http://docs.justyo.co/v1.0/docs/yo"
        }
    })
 
-   self.channel.send("Yo Location", options={
+   # Yo Location
+   self.channel.send(None, options={
        "yo": {
            "location": "35.0261581,135.7818476"
        }
@@ -47,5 +61,5 @@ You can send Yo Location or Yo Link by specifying options. For example:
 Please note that you can only send link or location, but not both.
 
 .. _Yo: https://www.justyo.co
-.. _API: http://docs.justyo.co/v1.0/docs/yo
+.. _API: http://docs.justyo.co/v2.0/docs/yo
 .. _Yo Dashboard: https://dev.justyo.co

--- a/tests/tests/backends/test_yo.py
+++ b/tests/tests/backends/test_yo.py
@@ -26,12 +26,18 @@ class YoChannelTestCase(TestCase):
         response.status_code = requests.codes.ok
         m.return_value = response
 
-        self.channel.send("Just Yo")
+        # Just Yo
+        self.channel.send(None)
 
-        self.channel.send("Yo Link", options={
+        # Yo with text
+        self.channel.send("🍣")
+
+        # Yo Link
+        self.channel.send(None, options={
             "yo": {"link": "http://docs.justyo.co/v1.0/docs/yo"}})
 
-        self.channel.send("Yo Location", options={
+        # Yo Location
+        self.channel.send(None, options={
             "yo": {"location": "35.0261581,135.7818476"}})
 
     @mock.patch("requests.post")
@@ -41,6 +47,6 @@ class YoChannelTestCase(TestCase):
         m.return_value = response
 
         with self.assertRaises(HttpError):
-            self.channel.send("Yo", fail_silently=False)
+            self.channel.send(None, fail_silently=False)
 
-        self.channel.send("Yo", fail_silently=True)
+        self.channel.send(None, fail_silently=True)


### PR DESCRIPTION
Yo API 2.0 で文字列が送信できるようになっているので対応する.