### PR TITLE
Drop Django 1.7 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = {py27,py33,py34,pypy,pypy3}-django{17,18}, {py27,py34,py35,pypy}-django{19,110}, coverage, docs, flake8
+envlist = {py27,py33,py34,pypy,pypy3}-django18, {py27,py34,py35,pypy}-django{19,110}, coverage, docs, flake8
 ; https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 
 [testenv]
 deps =
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
Django 1.7 is not officially supported now. We should drop its support.