### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ django-channels
    :target: https://travis-ci.org/ymyzk/django-channels
    :alt: Build Status
 .. image:: https://readthedocs.org/projects/django-channels/badge/?version=latest
-   :target: http://django-channels.readthedocs.org/
+   :target: https://django-channels.readthedocs.io/
    :alt: Documentation Status
 .. image:: https://codeclimate.com/github/ymyzk/django-channels/badges/gpa.svg
    :target: https://codeclimate.com/github/ymyzk/django-channels
@@ -73,6 +73,6 @@ Links
 * `Documentation`_
 * `GitHub`_
 
-.. _Documentation: http://django-channels.readthedocs.org/
+.. _Documentation: https://django-channels.readthedocs.io/
 .. _GitHub: https://github.com/ymyzk/django-channels
-.. _Quickstart: http://django-channels.readthedocs.org/en/latest/quickstart.html
+.. _Quickstart: https://django-channels.readthedocs.io/en/latest/quickstart.html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,5 +51,5 @@ Links
 * `Documentation`_
 * `GitHub`_
 
-.. _Documentation: http://django-channels.readthedocs.org/
+.. _Documentation: https://django-channels.readthedocs.io/
 .. _GitHub: https://github.com/ymyzk/django-channels


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.